### PR TITLE
Bugfix / Missing Packet Order Error

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -90,6 +90,7 @@ jobs:
             docker stop ${{ env.CONTAINER_NAME }}
             docker run -d \
               --rm \
+              --cap-add=sys_nice \
               --name ${{ env.CONTAINER_NAME }} \
               --net host \
               -v ${{ env.WORKDIR }}/data:/var/lib/mysql \

--- a/my.cnf
+++ b/my.cnf
@@ -2,3 +2,5 @@
 default_authentication_plugin=mysql_native_password
 collation_server=utf8mb4_unicode_ci
 character_set_server=utf8mb4
+max_allowed_packet=200M
+max_connections=1024


### PR DESCRIPTION
Trying to eliminate errors when MySQL sometimes throwing `Packets out of order` like error. Also In container logs there as a lot of `mbind` errors so new capability was added to a container.